### PR TITLE
Fix ASIO not found and option

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,6 +14,8 @@ class SimpleWebSocketServerConan(ConanFile):
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "MIT"  # Indicates license type of the packaged library; please use SPDX Identifiers https://spdx.org/licenses/
     no_copy_source = True
+    generators = "cmake"
+    exports_sources = "CMakeLists.txt"
 
     requires = (
         "OpenSSL/1.1.1c@conan/stable",
@@ -53,7 +55,7 @@ class SimpleWebSocketServerConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["USE_STANDALONE_ASIO"] = True
-        cmake.configure(source_folder=self._source_subfolder)
+        cmake.configure()
         return cmake
 
     def build(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -34,7 +34,6 @@ class SimpleWebSocketServerConan(ConanFile):
 
     def requirements(self):
         if self.options.use_asio_standalone:
-            self.default_options["asio:standalone"] = True
             self.requires("asio/1.13.0@bincrafters/stable")
         else:
             self.requires("boost_asio/1.69.0@bincrafters/stable")
@@ -54,7 +53,7 @@ class SimpleWebSocketServerConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        cmake.definitions["USE_STANDALONE_ASIO"] = True
+        cmake.definitions["USE_STANDALONE_ASIO"] = self.options.use_asio_standalone
         cmake.configure()
         return cmake
 


### PR DESCRIPTION
Hi! I have fixed the issue of ASIO not being found by CMake. Basically, the generator was missing from the recipe and the CMakeLists wrapper file was not exported to the Conan cache, so the recipe was executing the original project one instead of the wrapper one.

I have also fixed the asio standalone option that was not taking effect in CMake.

I have tried the recipe in Windows Visual Studio 15 and it still fails in the package method at cmake install time. Does the library has a cmake install step?

Please follow up the comments for other improvements and observations in the recipe and just ask if you have any question 😄 